### PR TITLE
feat(tts): add nineninesix.ai synthesis

### DIFF
--- a/lib/synth-audio.js
+++ b/lib/synth-audio.js
@@ -80,7 +80,8 @@ async function synthAudio(client, createHash, retrieveHash, logger, stats, { acc
   logger = logger || noopLogger;
 
   assert.ok(['google', 'aws', 'polly', 'microsoft', 'wellsaid', 'nvidia', 'elevenlabs',
-    'whisper', 'deepgram', 'deepgramflux', 'rimelabs', 'cartesia', 'inworld', 'resemble', 'murf', 'xai']
+    'whisper', 'deepgram', 'deepgramflux', 'rimelabs', 'cartesia', 'nineninesix', 'inworld', 'resemble',
+    'murf', 'xai']
     .includes(vendor) ||
   vendor.startsWith('custom'),
   `synthAudio supported vendors are google, aws, microsoft, nvidia and wellsaid ..etc, not ${vendor}`);
@@ -135,6 +136,10 @@ async function synthAudio(client, createHash, retrieveHash, logger, stats, { acc
   } else if ('cartesia' === vendor) {
     assert.ok(credentials.api_key, 'synthAudio requires api_key when cartesia is used');
     assert.ok(credentials.model_id, 'synthAudio requires model_id when cartesia is used');
+  } else if ('nineninesix' === vendor) {
+    assert.ok(voice, 'synthAudio requires voice when nineninesix is used');
+    assert.ok(credentials.api_key, 'synthAudio requires api_key when nineninesix is used');
+    assert.ok(credentials.model_id, 'synthAudio requires model_id when nineninesix is used');
   } else if ('murf' === vendor) {
     assert.ok(voice, 'synthAudio requires voice when murf is used');
     assert.ok(credentials.api_key, 'synthAudio requires api_key when murf is used');
@@ -210,6 +215,11 @@ async function synthAudio(client, createHash, retrieveHash, logger, stats, { acc
       case 'cartesia':
         audioData = await synthCartesia(logger, {
           credentials, options, stats, language, voice, key, text, renderForCaching, disableTtsStreaming,
+          disableTtsCache});
+        break;
+      case 'nineninesix':
+        audioData = await synthNineninesix(logger, {
+          credentials, stats, language, voice, key, text, renderForCaching, disableTtsStreaming,
           disableTtsCache});
         break;
       case 'inworld':
@@ -1421,6 +1431,61 @@ const synthCartesia = async(logger, {
     throw err;
   }
 
+};
+
+/* nineninesix.ai — a Cartesia-compatible API, but only raw/wav come back
+   (mp3 is rejected), so the cache render asks for wav rather than mp3. */
+const synthNineninesix = async(logger, {
+  credentials, stats, voice, language, key, text, renderForCaching, disableTtsStreaming, disableTtsCache
+}) => {
+  const {api_key, model_id} = credentials;
+
+  /* default to using the streaming interface, unless disabled by env var OR we want just a cache file */
+  if (!JAMBONES_DISABLE_TTS_STREAMING && !renderForCaching && !disableTtsStreaming) {
+    let params = '{';
+    params += `api_key=${api_key}`;
+    params += `,playback_id=${key}`;
+    params += `,model_id=${model_id}`;
+    params += ',vendor=nineninesix';
+    params += `,voice=${voice}`;
+    params += `,write_cache_file=${disableTtsCache ? 0 : 1}`;
+    if (language) params += `,language=${language}`;
+    params += '}';
+
+    return {
+      filePath: `say:${params}${text.replace(/\n/g, ' ').replace(/\r/g, ' ')}`,
+      servedFromCache: false,
+      rtt: 0
+    };
+  }
+
+  try {
+    const sampleRate = 8000;
+    const post = bent('https://api.nineninesix.ai', 'POST', 'buffer', {
+      'Authorization': `Bearer ${api_key}`,
+      'Content-Type': 'application/json'
+    });
+    const audioContent = await post('/tts/bytes', {
+      model_id,
+      transcript: text,
+      voice: {mode: 'id', id: voice},
+      ...(language && {language}),
+      output_format: {
+        container: 'wav',
+        encoding: 'pcm_s16le',
+        sample_rate: sampleRate
+      }
+    });
+    return {
+      audioContent,
+      extension: 'wav',
+      sampleRate
+    };
+  } catch (err) {
+    logger.info({err}, 'synth nineninesix returned error');
+    stats.increment('tts.count', ['vendor:nineninesix', 'accepted:no']);
+    throw err;
+  }
 };
 
 const synthResemble = async(logger, {

--- a/test/synth.js
+++ b/test/synth.js
@@ -1058,6 +1058,36 @@ test('Cartesia speech synth tests', async(t) => {
   client.quit();
 });
 
+test('nineninesix speech synth tests', async(t) => {
+  const fn = require('..');
+  const {synthAudio, client} = fn(opts, logger);
+
+  if (!process.env.NINENINESIX_API_KEY) {
+    t.pass('skipping nineninesix speech synth tests since NINENINESIX_API_KEY is not provided');
+    return t.end();
+  }
+  const text = 'Hi there and welcome to jambones! ' + Date.now();
+  try {
+    const opts = await synthAudio(stats, {
+      vendor: 'nineninesix',
+      credentials: {
+        api_key: process.env.NINENINESIX_API_KEY,
+        model_id: 'gepard-1.0'
+      },
+      language: 'en',
+      voice: '3ad7a827-7fd1-4954-bf35-47d4cc33d9ed',
+      text,
+      renderForCaching: true
+    });
+    t.ok(!opts.servedFromCache, `successfully synthed nineninesix audio to ${opts.filePath}`);
+
+  } catch (err) {
+    console.error(JSON.stringify(err));
+    t.end(err);
+  }
+  client.quit();
+});
+
 test('inworld speech synth', async(t) => {
   const fn = require('..');
   const {synthAudio, client} = fn(opts, logger);


### PR DESCRIPTION
Adds `nineninesix` to `synthAudio`.

- **Streaming arm** returns a `say:{vendor=nineninesix,...}` url whose param names match the mediajam dialect (jambonz/mediajam PR for the same branch).
- **Cache-render arm** POSTs `/tts/bytes`. The service emits raw or wav only — it rejects `mp3` outright — so this asks for `wav` rather than the mp3 most vendors use.

Credential is `api_key` + `model_id` (currently only `gepard-1.0`); voice is a UUID from the vendor's voice catalog.

Verified live against the real API: cache render produced a valid 8 kHz wav, the streaming arm emits the expected say: url, and a bad key surfaces a 401. Env-gated test added to `test/synth.js` (skips without `NINENINESIX_API_KEY`); pre-commit hook ran jslint + the full suite, 49/49 pass.

Once published, the dep needs bumping in both feature-server and api-server.

🤖 Generated with [Claude Code](https://claude.com/claude-code)