### PR TITLE
fix(deps): bump microsoft-cognitiveservices-speech-sdk to ^1.51.0 (GHSA-w5hq-g745-h8pq)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "bent": "^7.3.12",
         "debug": "^4.3.4",
         "google-protobuf": "^3.21.2",
-        "microsoft-cognitiveservices-speech-sdk": "1.38.0",
+        "microsoft-cognitiveservices-speech-sdk": "^1.51.0",
         "openai": "^4.98.0",
         "undici": "^7.5.0"
       },
@@ -758,6 +758,46 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@azure/abort-controller": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@azure/abort-controller/-/abort-controller-2.2.0.tgz",
+      "integrity": "sha512-fNAjWnA/nZ2jz31kxR/AqRaUT8ewHBw/WuBIosK0moMy1C9e5ValbDfFdIxJzVOOYaYkV/b2F1S4H/aHiqfVQg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      }
+    },
+    "node_modules/@azure/core-auth": {
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/@azure/core-auth/-/core-auth-1.11.0.tgz",
+      "integrity": "sha512-IUZydyTUkDnYdstOW9pFOOUQlBjAepK5teihDE3x6yxsPJs/hsAaaYpeGxdxrgtOiJbBKSjKW7MDk7AEhb4LRg==",
+      "license": "MIT",
+      "dependencies": {
+        "@azure/abort-controller": "^2.1.2",
+        "@azure/core-util": "^1.13.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      }
+    },
+    "node_modules/@azure/core-util": {
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/@azure/core-util/-/core-util-1.14.0.tgz",
+      "integrity": "sha512-9n2pWK61veAuN0V20t9lOuoV4CFMdyAZ1ygZzvBGk/pBBJRib/PjL9PLXa/aI2CcPpyHfqVsxxqLCYl6uZlfDw==",
+      "license": "MIT",
+      "dependencies": {
+        "@azure/abort-controller": "^2.1.2",
+        "@typespec/ts-http-runtime": "^0.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=22.0.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -2390,6 +2430,20 @@
       "version": "0.0.37",
       "resolved": "https://registry.npmjs.org/@types/webrtc/-/webrtc-0.0.37.tgz",
       "integrity": "sha512-JGAJC/ZZDhcrrmepU4sPLQLIOIAgs5oIK+Ieq90K8fdaNMhfdfqmYatJdgif1NDQtvrSlTOGJDUYHIDunuufOg=="
+    },
+    "node_modules/@typespec/ts-http-runtime": {
+      "version": "0.3.8",
+      "resolved": "https://registry.npmjs.org/@typespec/ts-http-runtime/-/ts-http-runtime-0.3.8.tgz",
+      "integrity": "sha512-bLMpVcWZNzq6lYOybwFwOAR1IXKcHnhUNqYeHjl1bET/qE3jFPFH+p8Wrh3rU4xwdnifPxmKNESBYnvnmc75aA==",
+      "license": "MIT",
+      "dependencies": {
+        "http-proxy-agent": "^7.0.0",
+        "https-proxy-agent": "^7.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      }
     },
     "node_modules/23": {
       "version": "0.0.0",
@@ -5278,17 +5332,18 @@
       }
     },
     "node_modules/microsoft-cognitiveservices-speech-sdk": {
-      "version": "1.38.0",
-      "resolved": "https://registry.npmjs.org/microsoft-cognitiveservices-speech-sdk/-/microsoft-cognitiveservices-speech-sdk-1.38.0.tgz",
-      "integrity": "sha512-NA6J4eIDkeR9iN83rcn77Kn5AWQcizDEn1tLMjzRvSovUNB1FrZe0mWYO0fsGltUwMl3Ns5OZ3lGw42PU4fEYA==",
+      "version": "1.51.0",
+      "resolved": "https://registry.npmjs.org/microsoft-cognitiveservices-speech-sdk/-/microsoft-cognitiveservices-speech-sdk-1.51.0.tgz",
+      "integrity": "sha512-BLLovv5PegOr5Lp52h4CSgL2c/ViFAh9LoU49ILNPyb/Z0giGI7nPV3xNLcmTtHLT+kfYNRGUIA62vORLzP8TA==",
       "license": "MIT",
       "dependencies": {
+        "@azure/core-auth": "^1.9.0",
         "@types/webrtc": "^0.0.37",
         "agent-base": "^6.0.1",
         "bent": "^7.3.12",
         "https-proxy-agent": "^4.0.0",
-        "uuid": "^9.0.0",
-        "ws": "^7.5.6"
+        "uuid": "^11.1.1",
+        "ws": "^8.21.0"
       }
     },
     "node_modules/microsoft-cognitiveservices-speech-sdk/node_modules/https-proxy-agent": {
@@ -5312,36 +5367,16 @@
       }
     },
     "node_modules/microsoft-cognitiveservices-speech-sdk/node_modules/uuid": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
-      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
+      "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
       "funding": [
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"
       ],
-      "bin": {
-        "uuid": "dist/bin/uuid"
-      }
-    },
-    "node_modules/microsoft-cognitiveservices-speech-sdk/node_modules/ws": {
-      "version": "7.5.10",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
-      "integrity": "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==",
       "license": "MIT",
-      "engines": {
-        "node": ">=8.3.0"
-      },
-      "peerDependencies": {
-        "bufferutil": "^4.0.1",
-        "utf-8-validate": "^5.0.2"
-      },
-      "peerDependenciesMeta": {
-        "bufferutil": {
-          "optional": true
-        },
-        "utf-8-validate": {
-          "optional": true
-        }
+      "bin": {
+        "uuid": "dist/esm/bin/uuid"
       }
     },
     "node_modules/mime-db": {
@@ -7924,6 +7959,34 @@
       "resolved": "https://registry.npmjs.org/@aws/lambda-invoke-store/-/lambda-invoke-store-0.2.4.tgz",
       "integrity": "sha512-iY8yvjE0y651BixKNPgmv1WrQc+GZ142sb0z4gYnChDDY2YqI4P/jsSopBWrKfAt7LOJAkOXt7rC/hms+WclQQ=="
     },
+    "@azure/abort-controller": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@azure/abort-controller/-/abort-controller-2.2.0.tgz",
+      "integrity": "sha512-fNAjWnA/nZ2jz31kxR/AqRaUT8ewHBw/WuBIosK0moMy1C9e5ValbDfFdIxJzVOOYaYkV/b2F1S4H/aHiqfVQg==",
+      "requires": {
+        "tslib": "^2.6.2"
+      }
+    },
+    "@azure/core-auth": {
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/@azure/core-auth/-/core-auth-1.11.0.tgz",
+      "integrity": "sha512-IUZydyTUkDnYdstOW9pFOOUQlBjAepK5teihDE3x6yxsPJs/hsAaaYpeGxdxrgtOiJbBKSjKW7MDk7AEhb4LRg==",
+      "requires": {
+        "@azure/abort-controller": "^2.1.2",
+        "@azure/core-util": "^1.13.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "@azure/core-util": {
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/@azure/core-util/-/core-util-1.14.0.tgz",
+      "integrity": "sha512-9n2pWK61veAuN0V20t9lOuoV4CFMdyAZ1ygZzvBGk/pBBJRib/PjL9PLXa/aI2CcPpyHfqVsxxqLCYl6uZlfDw==",
+      "requires": {
+        "@azure/abort-controller": "^2.1.2",
+        "@typespec/ts-http-runtime": "^0.3.0",
+        "tslib": "^2.6.2"
+      }
+    },
     "@babel/code-frame": {
       "version": "7.26.2",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.26.2.tgz",
@@ -9117,6 +9180,16 @@
       "version": "0.0.37",
       "resolved": "https://registry.npmjs.org/@types/webrtc/-/webrtc-0.0.37.tgz",
       "integrity": "sha512-JGAJC/ZZDhcrrmepU4sPLQLIOIAgs5oIK+Ieq90K8fdaNMhfdfqmYatJdgif1NDQtvrSlTOGJDUYHIDunuufOg=="
+    },
+    "@typespec/ts-http-runtime": {
+      "version": "0.3.8",
+      "resolved": "https://registry.npmjs.org/@typespec/ts-http-runtime/-/ts-http-runtime-0.3.8.tgz",
+      "integrity": "sha512-bLMpVcWZNzq6lYOybwFwOAR1IXKcHnhUNqYeHjl1bET/qE3jFPFH+p8Wrh3rU4xwdnifPxmKNESBYnvnmc75aA==",
+      "requires": {
+        "http-proxy-agent": "^7.0.0",
+        "https-proxy-agent": "^7.0.0",
+        "tslib": "^2.6.2"
+      }
     },
     "abort-controller": {
       "version": "3.0.0",
@@ -11106,16 +11179,17 @@
       "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g=="
     },
     "microsoft-cognitiveservices-speech-sdk": {
-      "version": "1.38.0",
-      "resolved": "https://registry.npmjs.org/microsoft-cognitiveservices-speech-sdk/-/microsoft-cognitiveservices-speech-sdk-1.38.0.tgz",
-      "integrity": "sha512-NA6J4eIDkeR9iN83rcn77Kn5AWQcizDEn1tLMjzRvSovUNB1FrZe0mWYO0fsGltUwMl3Ns5OZ3lGw42PU4fEYA==",
+      "version": "1.51.0",
+      "resolved": "https://registry.npmjs.org/microsoft-cognitiveservices-speech-sdk/-/microsoft-cognitiveservices-speech-sdk-1.51.0.tgz",
+      "integrity": "sha512-BLLovv5PegOr5Lp52h4CSgL2c/ViFAh9LoU49ILNPyb/Z0giGI7nPV3xNLcmTtHLT+kfYNRGUIA62vORLzP8TA==",
       "requires": {
+        "@azure/core-auth": "^1.9.0",
         "@types/webrtc": "^0.0.37",
         "agent-base": "^6.0.1",
         "bent": "^7.3.12",
         "https-proxy-agent": "^4.0.0",
-        "uuid": "^9.0.0",
-        "ws": "^7.5.6"
+        "uuid": "^11.1.1",
+        "ws": "^8.21.0"
       },
       "dependencies": {
         "https-proxy-agent": {
@@ -11135,15 +11209,9 @@
           }
         },
         "uuid": {
-          "version": "9.0.1",
-          "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
-          "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA=="
-        },
-        "ws": {
-          "version": "7.5.10",
-          "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
-          "integrity": "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==",
-          "requires": {}
+          "version": "11.1.1",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
+          "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ=="
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "bent": "^7.3.12",
     "debug": "^4.3.4",
     "google-protobuf": "^3.21.2",
-    "microsoft-cognitiveservices-speech-sdk": "1.38.0",
+    "microsoft-cognitiveservices-speech-sdk": "^1.51.0",
     "openai": "^4.98.0",
     "undici": "^7.5.0"
   },


### PR DESCRIPTION
## What

Bumps `microsoft-cognitiveservices-speech-sdk` from an exact pin of `1.38.0` to `^1.51.0`.

## Why

The Azure speech SDK pulls in `uuid` <11.1.1, which carries [GHSA-w5hq-g745-h8pq](https://github.com/advisories/GHSA-w5hq-g745-h8pq) — missing buffer bounds check in v3/v5/v6 when a `buf` argument is provided. The advisory covers Azure SDK 1.14.0–1.50.0; 1.51.0 clears it.

The exact pin has been there since the initial commit with no recorded reason for it, so this also loosens it to a caret range — future patches then arrive without another PR.

## Risk

Low. The only consumer is `lib/synth-audio.js`, which uses `SpeechConfig`, `SpeechSynthesizer`, `ResultReason`, `CancellationDetails`, and `SpeechSynthesisOutputFormat`. All five are present and unchanged in 1.51.0.

Verified: lint passes, `lib/synth-audio.js` loads against 1.51.0, and the full test suite passes 50/50. Note the Azure-specific tests self-skip without `MICROSOFT_API_KEY`/`MICROSOFT_REGION`, so a live Azure TTS smoke test before publishing is worthwhile.

## Note

`npm audit` still flags `undici` (direct dep, non-breaking lockfile fix) and `uuid` via `nyc` (devDependency only). Both are out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)