### PR TITLE
fix(deps): drop unused undici dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,8 +20,7 @@
         "debug": "^4.3.4",
         "google-protobuf": "^3.21.2",
         "microsoft-cognitiveservices-speech-sdk": "^1.51.0",
-        "openai": "^4.98.0",
-        "undici": "^7.5.0"
+        "openai": "^4.98.0"
       },
       "devDependencies": {
         "config": "^4.2.0",
@@ -7066,15 +7065,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/undici": {
-      "version": "7.24.5",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.24.5.tgz",
-      "integrity": "sha512-3IWdCpjgxp15CbJnsi/Y9TCDE7HWVN19j1hmzVhoAkY/+CJx449tVxT5wZc1Gwg8J+P0LWvzlBzxYRnHJ+1i7Q==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=20.18.1"
-      }
-    },
     "node_modules/undici-types": {
       "version": "5.26.5",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
@@ -12414,11 +12404,6 @@
         "has-symbols": "^1.0.3",
         "which-boxed-primitive": "^1.0.2"
       }
-    },
-    "undici": {
-      "version": "7.24.5",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.24.5.tgz",
-      "integrity": "sha512-3IWdCpjgxp15CbJnsi/Y9TCDE7HWVN19j1hmzVhoAkY/+CJx449tVxT5wZc1Gwg8J+P0LWvzlBzxYRnHJ+1i7Q=="
     },
     "undici-types": {
       "version": "5.26.5",

--- a/package.json
+++ b/package.json
@@ -36,8 +36,7 @@
     "debug": "^4.3.4",
     "google-protobuf": "^3.21.2",
     "microsoft-cognitiveservices-speech-sdk": "^1.51.0",
-    "openai": "^4.98.0",
-    "undici": "^7.5.0"
+    "openai": "^4.98.0"
   },
   "devDependencies": {
     "config": "^4.2.0",


### PR DESCRIPTION
## What

Removes `undici` from `dependencies`. No source changes.

## Why

`undici` is declared as a direct dependency but is never used. A grep across `index.js`, `lib/` and `stubs/` finds no reference to `undici`, `ProxyAgent`, `setGlobalDispatcher` or `Dispatcher` — the only occurrence in the whole repo is the line in `package.json`. The single HTTP call in `lib/synth-audio.js` uses the global `fetch`, and Azure proxy support goes through the SDK's own `setProxy` plus the `http_proxy_ip`/`http_proxy_port` params.

Two things this fixes:

1. **Clears seven open undici advisories** from `npm audit` for this package and everything downstream of it (cache poisoning, response desync, CRLF injection, cookie attribute injection, response queue poisoning).
2. **Stops a duplicate undici in consumer trees.** feature-server declares `undici: ^8.0.2` and uses it directly (`lib/utils/http-requestor.js`, the s2s LLM drivers); speech-utils was dragging a second 7.x copy in alongside it for nothing.

Removing the dependency was preferred over bumping it — it is the smaller change and the dead weight should not be here regardless of the advisories. If you would rather keep it declared, the alternative is `^7.29.0`, which also clears all seven.

## Risk

Low, but not zero: if any consumer is implicitly relying on undici being hoisted out of speech-utils rather than declaring it, that consumer breaks. feature-server declares it properly, so it is unaffected. Worth a quick check of any other repo that requires undici without listing it.

Verified: lint passes, full test suite passes 105/105 against live vendor credentials (Google, Gemini, AWS, Azure, ElevenLabs, Deepgram, Rimelabs, custom vendor).

🤖 Generated with [Claude Code](https://claude.com/claude-code)