### PR TITLE
fix(deps): remove junk "23" dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,6 @@
       "version": "1.0.14",
       "license": "MIT",
       "dependencies": {
-        "23": "^0.0.0",
         "@aws-sdk/client-polly": "^3.496.0",
         "@aws-sdk/client-sts": "^3.496.0",
         "@cartesia/cartesia-js": "^2.2.7",
@@ -2443,12 +2442,6 @@
       "engines": {
         "node": ">=22.0.0"
       }
-    },
-    "node_modules/23": {
-      "version": "0.0.0",
-      "resolved": "https://registry.npmjs.org/23/-/23-0.0.0.tgz",
-      "integrity": "sha512-uAETf9Okr72trtp1pNXYKhFCTTI1EKGcYMA8gw3jLGhlbaDX+grrNToEWrpt8luxRAvrZWBTvyB5wk3PpNjGQQ==",
-      "license": "ISC"
     },
     "node_modules/abort-controller": {
       "version": "3.0.0",
@@ -7367,11 +7360,6 @@
     }
   },
   "dependencies": {
-    "23": {
-      "version": "0.0.0",
-      "resolved": "https://registry.npmjs.org/23/-/23-0.0.0.tgz",
-      "integrity": "sha512-uAETf9Okr72trtp1pNXYKhFCTTI1EKGcYMA8gw3jLGhlbaDX+grrNToEWrpt8luxRAvrZWBTvyB5wk3PpNjGQQ=="
-    },
     "@aashutoshrathi/word-wrap": {
       "version": "1.2.6",
       "resolved": "https://registry.npmjs.org/@aashutoshrathi/word-wrap/-/word-wrap-1.2.6.tgz",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,6 @@
   },
   "homepage": "https://github.com/jambonz/speech-utils#readme",
   "dependencies": {
-    "23": "^0.0.0",
     "@aws-sdk/client-polly": "^3.496.0",
     "@aws-sdk/client-sts": "^3.496.0",
     "@cartesia/cartesia-js": "^2.2.7",


### PR DESCRIPTION
## What

Removes `"23": "^0.0.0"` from `dependencies`. No source changes.

## Why

It is not a real dependency. `23` on npm is an empty placeholder package — version 0.0.0, no dependencies, published by an unrelated third-party maintainer — that landed here from a stray `npm install`. Nothing in this package references it (no `require('23')` anywhere in the repo).

Beyond being noise in `package.json`, it is a small supply-chain liability: a squatted single-number name we do not control, shipped into the tree of every consumer of speech-utils.

## Risk

None. Removing it changes nothing at runtime.

Verified: lint passes, full test suite passes 105/105 against live vendor credentials.

🤖 Generated with [Claude Code](https://claude.com/claude-code)