### PR TITLE
fix(inworld): read pitch and speakingRate from audioConfig in the say: params

### DIFF
--- a/lib/synth-audio.js
+++ b/lib/synth-audio.js
@@ -941,8 +941,9 @@ const synthInworld = async(logger, {
     params += `,voice=${voice}`;
     params += `,write_cache_file=${disableTtsCache ? 0 : 1}`;
     if (opts.temperature) params += `,temperature=${opts.temperature}`;
-    if (opts.audioConfig?.pitch) params += `,pitch=${opts.pitch}`;
-    if (opts.audioConfig?.speakingRate) params += `,speakingRate=${opts.speakingRate}`;
+    /* pitch and speakingRate are nested under audioConfig, matching Inworld's API */
+    if (opts.audioConfig?.pitch) params += `,pitch=${opts.audioConfig.pitch}`;
+    if (opts.audioConfig?.speakingRate) params += `,speakingRate=${opts.audioConfig.speakingRate}`;
     params += '}';
 
     return {

--- a/test/synth.js
+++ b/test/synth.js
@@ -1147,6 +1147,54 @@ test('inworld speech synth', async(t) => {
   client.quit();
 });
 
+test('inworld streaming say: params', async(t) => {
+  const fn = require('..');
+  const {synthAudio, client} = fn(opts, logger);
+
+  /* the streaming branch builds the say: path without calling the vendor,
+     so this needs no credentials
+   */
+  try {
+    let result = await synthAudio(stats, {
+      vendor: 'inworld',
+      credentials: {api_key: 'test-key', model_id: 'inworld-tts-1.5-mini'},
+      language: 'en',
+      voice: 'Ashley',
+      text: 'This is a test of inworld streaming.',
+      options: {temperature: 0.9, audioConfig: {pitch: 2.5, speakingRate: 1.2}},
+      disableTtsCache: true
+    });
+    t.ok(result.filePath.startsWith('say:'), 'inworld returns streaming say: path');
+    t.ok(result.filePath.includes('vendor=inworld'), 'streaming path contains vendor=inworld');
+    t.ok(result.filePath.includes('voice=Ashley'), 'streaming path contains voice');
+    t.ok(result.filePath.includes('model_id=inworld-tts-1.5-mini'), 'streaming path contains model_id');
+    t.ok(result.filePath.includes('temperature=0.9'), 'streaming path contains temperature');
+    /* pitch and speakingRate are nested under audioConfig; they used to be read
+       from the top level and emitted as "undefined"
+     */
+    t.ok(result.filePath.includes('speakingRate=1.2'), 'audioConfig.speakingRate reaches the say: params');
+    t.ok(result.filePath.includes('pitch=2.5'), 'audioConfig.pitch reaches the say: params');
+    t.ok(!result.filePath.includes('undefined'), 'no undefined values in the say: params');
+
+    /* options omitted entirely: no stray keys */
+    result = await synthAudio(stats, {
+      vendor: 'inworld',
+      credentials: {api_key: 'test-key', model_id: 'inworld-tts-1.5-mini'},
+      language: 'en',
+      voice: 'Ashley',
+      text: 'This is a test of inworld streaming.',
+      disableTtsCache: true
+    });
+    t.ok(!result.filePath.includes('speakingRate='), 'speakingRate omitted when unset');
+    t.ok(!result.filePath.includes('pitch='), 'pitch omitted when unset');
+    t.ok(!result.filePath.includes('undefined'), 'no undefined values when options are omitted');
+  } catch (err) {
+    console.error(JSON.stringify(err));
+    t.end(err);
+  }
+  client.quit();
+});
+
 test('resemble speech synth', async(t) => {
   const fn = require('..');
   const {synthAudio, client} = fn(opts, logger);


### PR DESCRIPTION
The Inworld streaming `say:` path guards on `opts.audioConfig?.pitch` / `opts.audioConfig?.speakingRate` but interpolates `opts.pitch` / `opts.speakingRate`:

```js
if (opts.audioConfig?.pitch) params += `,pitch=${opts.pitch}`;
if (opts.audioConfig?.speakingRate) params += `,speakingRate=${opts.speakingRate}`;
```

Those top-level properties are undefined, so the guard fires on the nested value and then emits `pitch=undefined,speakingRate=undefined`. Anyone setting these under `audioConfig` — which is what the docs and the portal's `DEFAULT_INWORLD_OPTIONS` both tell you to do — has their setting silently dropped.

## Why now

This has been live on the FreeSWITCH backend all along (`ttsStreamingSupported` returns true unconditionally there). It was *not* reachable on mediajam, because `inworld` was absent from `MediajamTtsStreamingVendors`, so `tts-task` set `disableTtsStreaming` and synthesis took the non-streaming branch, where `audioConfig` is spread through correctly.

jambonz/feature-server#165 adds `inworld` to that list, which flips the default backend onto this branch — so the bug would start shipping there too. It also creates an inconsistency worth avoiding: on the token-streaming path the feature-server descriptor sets `INWORLD_TTS_STREAMING_SPEAKING_RATE` correctly, so the same option would work for `agent` and be ignored for `say`.

## Testing

New `inworld streaming say: params` test. It needs no credentials — the streaming branch builds the path without calling the vendor — so it runs in CI unconditionally, unlike the existing `inworld speech synth` test.

Verified it actually catches the bug: against the unfixed code, assertions 6 and 7 fail (`speakingRate`/`pitch` absent); with the fix, 11/11 pass. Also asserts the params contain no `undefined` at all, and that both keys are omitted when `options` is not supplied.

`eslint` error count on the touched files is unchanged (29 before, 29 after, no new rules triggered — all pre-existing in `test/synth.js`).

## Release note

This needs a publish and a dependency bump in feature-server and api-server before it reaches any server. Nothing in Inworld streaming support depends on it — jambonz/mediajam#94 and jambonz/feature-server#165 work against the currently published 1.0.15.

🤖 Generated with [Claude Code](https://claude.com/claude-code)