### PR TITLE
test(inworld): gate the say: param test on INWORLD_API_KEY

### DIFF
--- a/test/synth.js
+++ b/test/synth.js
@@ -1148,16 +1148,31 @@ test('inworld speech synth', async(t) => {
 });
 
 test('inworld streaming say: params', async(t) => {
+  /* This test asserts the streaming say: path, so it must run with streaming
+     enabled. The Google non-streaming test above sets
+     JAMBONES_DISABLE_TTS_STREAMING and, on its no-credentials skip path,
+     deletes the env var WITHOUT clearing the require cache — so lib/config can
+     still be holding 'true' by the time we get here. Re-require to be
+     independent of what ran before us.
+   */
+  delete process.env.JAMBONES_DISABLE_TTS_STREAMING;
+  delete require.cache[require.resolve('../lib/config')];
+  delete require.cache[require.resolve('../lib/synth-audio')];
+  delete require.cache[require.resolve('..')];
+
   const fn = require('..');
   const {synthAudio, client} = fn(opts, logger);
 
-  /* the streaming branch builds the say: path without calling the vendor,
-     so this needs no credentials
-   */
+  if (!process.env.INWORLD_API_KEY) {
+    t.pass('skipping inworld streaming say: param tests since INWORLD_API_KEY is not provided');
+    client.quit();
+    return t.end();
+  }
+
   try {
     let result = await synthAudio(stats, {
       vendor: 'inworld',
-      credentials: {api_key: 'test-key', model_id: 'inworld-tts-1.5-mini'},
+      credentials: {api_key: process.env.INWORLD_API_KEY, model_id: 'inworld-tts-1.5-mini'},
       language: 'en',
       voice: 'Ashley',
       text: 'This is a test of inworld streaming.',
@@ -1179,7 +1194,7 @@ test('inworld streaming say: params', async(t) => {
     /* options omitted entirely: no stray keys */
     result = await synthAudio(stats, {
       vendor: 'inworld',
-      credentials: {api_key: 'test-key', model_id: 'inworld-tts-1.5-mini'},
+      credentials: {api_key: process.env.INWORLD_API_KEY, model_id: 'inworld-tts-1.5-mini'},
       language: 'en',
       voice: 'Ashley',
       text: 'This is a test of inworld streaming.',


### PR DESCRIPTION
Fixes the `npm test` breakage introduced by #155 — my fault. The test I added there ran unconditionally, so `npm test` failed without credentials, which is the path husky's `pre-commit` hook takes (`npm run jslint:fix || true; npm test`). That is why `npm version patch` could not create its commit.

Two separate causes, both fixed:

**1. No credential gate.** Every other vendor test in `test/synth.js` skips when its key is absent; mine did not, on the reasoning that the streaming branch builds the `say:` path without calling the vendor. That reasoning was wrong in context — see below. It now skips without `INWORLD_API_KEY`, and closes its redis client on the skip path so the run can still exit (an unclosed client keeps the event loop alive).

**2. It depended on leaked module state.** `lib/config` captures `JAMBONES_DISABLE_TTS_STREAMING` at require time. The Google non-streaming test sets it and clears the require cache; its `finally` block cleans up both. But its **no-credentials skip path** at `test/synth.js:553` deletes the env var *without* clearing the cache:

```js
if (!process.env.GCP_FILE && !process.env.GCP_JSON_KEY) {
  t.pass('skipping ...');
  delete process.env.JAMBONES_DISABLE_TTS_STREAMING;   // cache still holds 'true'
  return t.end();
}
```

So with no GCP credentials, every test after that point sees streaming disabled. `synthInworld` then took the non-streaming branch and attempted a real POST to `api.inworld.ai` with the fake key. Confirmed directly:

```
config sees JAMBONES_DISABLE_TTS_STREAMING = "true" (env is now undefined)
```

The test now re-requires `lib/config` / `lib/synth-audio` with streaming enabled, so it is independent of what ran before it — the same setup the Google *streaming* test does at line 268.

## Verification

- no key: skips, process exits 0
- with a key, **under the leaked state**: 11/11 pass
- re-introducing the #155 bug still fails 3 assertions, so the regression value is intact
- `npm run jslint` (`index.js lib`) reports 0 errors; this change is test-only

## Note on the underlying leak

I did not touch line 553. Adding the cache-clear there would fix this for every test that follows, not just mine, but it flips the module state other tests currently inherit and could surface unrelated pre-existing failures — worth doing deliberately rather than inside this fix. Happy to open it separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
