### PR TITLE
fix(tts): forward gradium json_config to the streaming path

### DIFF
--- a/lib/synth-audio.js
+++ b/lib/synth-audio.js
@@ -1463,6 +1463,10 @@ const synthGradium = async(logger, {
     params += `,write_cache_file=${disableTtsCache ? 0 : 1}`;
     if (model_id) params += `,model_id=${model_id}`;
     if (pronunciation_id) params += `,pronunciation_id=${pronunciation_id}`;
+    /* the say: param parser is brace-aware, so a nested json object survives intact */
+    if (json_config) {
+      params += `,json_config=${typeof json_config === 'string' ? json_config : JSON.stringify(json_config)}`;
+    }
     params += '}';
 
     return {


### PR DESCRIPTION
`synthGradium` destructured `json_config` from `options` but only forwarded `pronunciation_id` into the `say:` param block. As a result the setting could only ever reach the cache-render POST — never mediajam's streaming dialect, which is the path used for live calls.

mediajam's `say:` parser is brace-aware, so a nested JSON object survives the param block intact (verified: a `json_config={"temp":0.7,"cfg_coef":2.5}` value round-trips unmangled, and params following it are not lost). Accepts either an object or an already-encoded string.

Note: the setup frame currently carries `json_config` as a **string**. Whether gradium expects an object is an open question with their engineering team; if it's an object that becomes a one-line change in mediajam's `gradium.go`. This PR is the prerequisite either way.

Verified: lint clean, full test suite 51/51.

🤖 Generated with [Claude Code](https://claude.com/claude-code)