### PR TITLE
fix(tts): use a current nineninesix voice id in the synth test

### DIFF
--- a/test/synth.js
+++ b/test/synth.js
@@ -1104,7 +1104,7 @@ test('nineninesix speech synth tests', async(t) => {
         model_id: 'gepard-1.0'
       },
       language: 'en',
-      voice: '3ad7a827-7fd1-4954-bf35-47d4cc33d9ed',
+      voice: '775e4dfd-819c-4325-92ec-250f487ef7e3',
       text,
       renderForCaching: true
     });


### PR DESCRIPTION
nineninesix.ai replaced its entire voice catalog — none of the previously published voice ids resolve any more — and it now rejects unknown ids with `voice_not_found` instead of silently falling back to a default. The env-gated test in `test/synth.js` still referenced a retired id, so it failed for anyone running with `NINENINESIX_API_KEY` set.

Swapped to Jamie (en-US), `775e4dfd-819c-4325-92ec-250f487ef7e3`, which is in the current catalog. Verified against the live API.

Test-only; no change to `lib/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)